### PR TITLE
v1.0.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - 2025-09-02
+
+### Added
+
+- Conditional deployment of CloudFront access logs to support regions that don't support standard logging (legacy)
+- Missing AppConfig Lambda layer extension ARN for eu-central-2 region
+
+### Fixed
+
+- Deployment failures in regions that don't support CloudFront standard access logging (legacy)
+
 ## [1.0.3] - 2025-07-25
 
 ### Security

--- a/docs/openapi/innovation-sandbox-api.yaml
+++ b/docs/openapi/innovation-sandbox-api.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: Innovation Sandbox on AWS
   description: API documentation for the Innovation Sandbox on AWS solution.
-  version: 1.0.3
+  version: 1.0.4
   license:
     name: Apache 2.0
     url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amzn/innovation-sandbox-on-aws",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amzn/innovation-sandbox-on-aws",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0",
       "workspaces": [
         "source/frontend",
@@ -5646,316 +5646,6 @@
         "@noble/hashes": "^1.1.5"
       }
     },
-    "node_modules/@parcel/watcher": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
-      "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "detect-libc": "^1.0.3",
-        "is-glob": "^4.0.3",
-        "micromatch": "^4.0.5",
-        "node-addon-api": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "@parcel/watcher-android-arm64": "2.5.1",
-        "@parcel/watcher-darwin-arm64": "2.5.1",
-        "@parcel/watcher-darwin-x64": "2.5.1",
-        "@parcel/watcher-freebsd-x64": "2.5.1",
-        "@parcel/watcher-linux-arm-glibc": "2.5.1",
-        "@parcel/watcher-linux-arm-musl": "2.5.1",
-        "@parcel/watcher-linux-arm64-glibc": "2.5.1",
-        "@parcel/watcher-linux-arm64-musl": "2.5.1",
-        "@parcel/watcher-linux-x64-glibc": "2.5.1",
-        "@parcel/watcher-linux-x64-musl": "2.5.1",
-        "@parcel/watcher-win32-arm64": "2.5.1",
-        "@parcel/watcher-win32-ia32": "2.5.1",
-        "@parcel/watcher-win32-x64": "2.5.1"
-      }
-    },
-    "node_modules/@parcel/watcher-android-arm64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
-      "integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-darwin-arm64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
-      "integrity": "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-darwin-x64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
-      "integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-freebsd-x64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
-      "integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm-glibc": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
-      "integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm-musl": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
-      "integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm64-glibc": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
-      "integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm64-musl": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
-      "integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-x64-glibc": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
-      "integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-x64-musl": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
-      "integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-arm64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
-      "integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-ia32": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
-      "integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-x64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
-      "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -10083,20 +9773,6 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "detect-libc": "bin/detect-libc.js"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/devlop": {
@@ -17224,14 +16900,6 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
-    "node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -21704,17 +21372,17 @@
     },
     "source/common": {
       "name": "@amzn/innovation-sandbox-commons",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0"
     },
     "source/e2e": {
       "name": "@amzn/innovation-sandbox-e2e",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0"
     },
     "source/frontend": {
       "name": "@amzn/innovation-sandbox-frontend",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-northstar/ui": "^1.4.2",
@@ -21780,7 +21448,7 @@
     },
     "source/infrastructure": {
       "name": "@amzn/innovation-sandbox-infrastructure",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0",
       "bin": {
         "infrastructure": "bin/app.js"
@@ -21796,107 +21464,107 @@
     },
     "source/lambdas/account-cleanup/initialize-cleanup": {
       "name": "@amzn/innovation-sandbox-initialize-cleanup",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0"
     },
     "source/lambdas/account-management/account-drift-monitoring": {
       "name": "@amzn/innovation-sandbox-account-drift-monitoring",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0"
     },
     "source/lambdas/account-management/account-lifecycle-management": {
       "name": "@amzn/innovation-sandbox-account-lifecycle-management",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0"
     },
     "source/lambdas/account-management/lease-monitoring": {
       "name": "@amzn/innovation-sandbox-lease-monitoring",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0"
     },
     "source/lambdas/api/accounts": {
       "name": "@amzn/innovation-sandbox-accounts",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0"
     },
     "source/lambdas/api/authorizer": {
       "name": "@amzn/innovation-sandbox-authorizer",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0"
     },
     "source/lambdas/api/configurations": {
       "name": "@amzn/innovation-sandbox-configurations",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0"
     },
     "source/lambdas/api/lease-templates": {
       "name": "@amzn/innovation-sandbox-lease-templates",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0"
     },
     "source/lambdas/api/leases": {
       "name": "@amzn/innovation-sandbox-leases",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0"
     },
     "source/lambdas/api/sso-handler": {
       "name": "@amzn/innovation-sandbox-sso-handler",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0"
     },
     "source/lambdas/custom-resources/cost-allocation-tag-activator": {
       "name": "@amzn/innovation-sandbox-cost-allocation-tag-activator",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0"
     },
     "source/lambdas/custom-resources/deployment-uuid": {
       "name": "@amzn/innovation-sandbox-deployment-uuid",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0"
     },
     "source/lambdas/custom-resources/idc-configurer": {
       "name": "@amzn/innovation-sandbox-idc-configurer",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0"
     },
     "source/lambdas/custom-resources/shared-json-param-parser": {
       "name": "@amzn/innovation-sandbox-shared-json-param-parser",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0"
     },
     "source/lambdas/helpers/secret-rotator": {
       "name": "@amzn/innovation-sandbox-secret-rotator",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0"
     },
     "source/lambdas/metrics/cost-reporting": {
       "name": "@amzn/innovation-sandbox-cost-reporting",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0"
     },
     "source/lambdas/metrics/deployment-summary-heartbeat": {
       "name": "@amzn/innovation-sandbox-metrics-heartbeat",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0"
     },
     "source/lambdas/metrics/log-archiving": {
       "name": "@amzn/innovation-sandbox-log-archiving",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0"
     },
     "source/lambdas/metrics/log-subscriber": {
       "name": "@amzn/innovation-sandbox-metrics-log-subscriber",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0"
     },
     "source/lambdas/notification/email-notification": {
       "name": "@amzn/innovation-sandbox-email-notification",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0"
     },
     "source/layers/common": {
       "name": "@amzn/innovation-sandbox-layer-commons",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@amzn/innovation-sandbox-commons": "file:../../common"
@@ -21904,7 +21572,7 @@
     },
     "source/layers/dependencies": {
       "name": "@amzn/innovation-sandbox-layer-dependencies",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-lambda-powertools/logger": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amzn/innovation-sandbox-on-aws",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Innovation Sandbox on AWS (SO0284)",
   "scripts": {
     "test": "vitest run --coverage",

--- a/solution-manifest.yaml
+++ b/solution-manifest.yaml
@@ -1,6 +1,6 @@
 id: SO0284
 name: innovation-sandbox-on-aws
-version: v1.0.3
+version: v1.0.4
 cloudformation_templates:
   - template: InnovationSandbox-AccountPool.template
     main_template: true

--- a/source/common/package.json
+++ b/source/common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amzn/innovation-sandbox-commons",
   "description": "Common - Innovation Sandbox on AWS (SO0284)",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "build": "tsc",
     "test": "vitest run"

--- a/source/e2e/package.json
+++ b/source/e2e/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amzn/innovation-sandbox-e2e",
   "description": "E2E Tests - Innovation Sandbox on AWS (SO0284)",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "build": "tsc",
     "e2e": "vitest run --config ./vitest.config.e2e.ts",

--- a/source/frontend/package.json
+++ b/source/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "@amzn/innovation-sandbox-frontend",
   "description": "Frontend - Innovation Sandbox on AWS (SO0284)",
   "private": true,
-  "version": "1.0.3",
+  "version": "1.0.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/source/infrastructure/lib/components/config/app-config-lambda-extension.ts
+++ b/source/infrastructure/lib/components/config/app-config-lambda-extension.ts
@@ -25,6 +25,8 @@ const layerArns: { [key: string]: string } = {
     "arn:aws:lambda:ca-west-1:436199621743:layer:AWS-AppConfig-Extension-Arm64:47",
   "eu-central-1":
     "arn:aws:lambda:eu-central-1:066940009817:layer:AWS-AppConfig-Extension-Arm64:132",
+  "eu-central-2":
+    "arn:aws:lambda:eu-central-2:758369105281:layer:AWS-AppConfig-Extension-Arm64:64",
   "eu-west-1":
     "arn:aws:lambda:eu-west-1:434848589818:layer:AWS-AppConfig-Extension-Arm64:127",
   "eu-west-2":

--- a/source/infrastructure/package.json
+++ b/source/infrastructure/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amzn/innovation-sandbox-infrastructure",
   "description": "Infrastructure - Innovation Sandbox on AWS (SO0284)",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "bin": {
     "infrastructure": "bin/app.js"
   },

--- a/source/infrastructure/test/__snapshots__/snapshots.test.ts.snap
+++ b/source/infrastructure/test/__snapshots__/snapshots.test.ts.snap
@@ -165,13 +165,13 @@ exports[`IdcStack Snapshot > matches the snapshot 1`] = `
         "deploymentMode": "prod",
         "logLevel": "INFO",
         "publicEcrRegistry": "public.ecr.aws/aws-solutions",
-        "publicEcrTag": "v1.0.3",
+        "publicEcrTag": "v1.0.4",
         "s3LogsArchiveRetentionInDays": 365,
         "s3LogsGlacierRetentionInDays": 2555,
         "sendAnonymizedUsageMetrics": "true",
         "solutionId": "SO0284",
         "solutionName": "innovation-sandbox-on-aws",
-        "version": "v1.0.3",
+        "version": "v1.0.4",
       },
     },
   },
@@ -537,7 +537,7 @@ exports[`IdcStack Snapshot > matches the snapshot 1`] = `
               ],
             },
             "POWERTOOLS_SERVICE_NAME": "IdcConfigurer",
-            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.3",
+            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.4",
           },
         },
         "FunctionName": {
@@ -1714,13 +1714,13 @@ exports[`IsbAccountPoolStack Snapshot > matches the snapshot 1`] = `
         "deploymentMode": "prod",
         "logLevel": "INFO",
         "publicEcrRegistry": "public.ecr.aws/aws-solutions",
-        "publicEcrTag": "v1.0.3",
+        "publicEcrTag": "v1.0.4",
         "s3LogsArchiveRetentionInDays": 365,
         "s3LogsGlacierRetentionInDays": 2555,
         "sendAnonymizedUsageMetrics": "true",
         "solutionId": "SO0284",
         "solutionName": "innovation-sandbox-on-aws",
-        "version": "v1.0.3",
+        "version": "v1.0.4",
       },
     },
   },
@@ -2040,7 +2040,7 @@ exports[`IsbAccountPoolStack Snapshot > matches the snapshot 1`] = `
               ],
             },
             "POWERTOOLS_SERVICE_NAME": "innovation-sandbox",
-            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.3",
+            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.4",
           },
         },
         "FunctionName": {
@@ -3953,6 +3953,118 @@ exports[`IsbComputeStack Snapshot > matches the snapshot 1`] = `
         },
       ],
     },
+    "CloudFrontUiApiSupportsCloudFrontLoggingF1020F6E": {
+      "Fn::Not": [
+        {
+          "Fn::Or": [
+            {
+              "Fn::Or": [
+                {
+                  "Fn::Equals": [
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    "af-south-1",
+                  ],
+                },
+                {
+                  "Fn::Equals": [
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    "ap-east-1",
+                  ],
+                },
+                {
+                  "Fn::Equals": [
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    "ap-south-2",
+                  ],
+                },
+                {
+                  "Fn::Equals": [
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    "ap-southeast-3",
+                  ],
+                },
+                {
+                  "Fn::Equals": [
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    "ap-southeast-4",
+                  ],
+                },
+                {
+                  "Fn::Equals": [
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    "ca-west-1",
+                  ],
+                },
+                {
+                  "Fn::Equals": [
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    "eu-south-1",
+                  ],
+                },
+                {
+                  "Fn::Equals": [
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    "eu-south-2",
+                  ],
+                },
+                {
+                  "Fn::Equals": [
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    "eu-central-2",
+                  ],
+                },
+                {
+                  "Fn::Equals": [
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    "il-central-1",
+                  ],
+                },
+              ],
+            },
+            {
+              "Fn::Or": [
+                {
+                  "Fn::Equals": [
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    "me-south-1",
+                  ],
+                },
+                {
+                  "Fn::Equals": [
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    "me-central-1",
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
     "SendAnonymizedMetricsCondition": {
       "Fn::Equals": [
         {
@@ -4029,6 +4141,9 @@ exports[`IsbComputeStack Snapshot > matches the snapshot 1`] = `
       },
       "eu-central-1": {
         "arn": "arn:aws:lambda:eu-central-1:066940009817:layer:AWS-AppConfig-Extension-Arm64:132",
+      },
+      "eu-central-2": {
+        "arn": "arn:aws:lambda:eu-central-2:758369105281:layer:AWS-AppConfig-Extension-Arm64:64",
       },
       "eu-north-1": {
         "arn": "arn:aws:lambda:eu-north-1:646970417810:layer:AWS-AppConfig-Extension-Arm64:118",
@@ -4215,13 +4330,13 @@ exports[`IsbComputeStack Snapshot > matches the snapshot 1`] = `
         "deploymentMode": "prod",
         "logLevel": "INFO",
         "publicEcrRegistry": "public.ecr.aws/aws-solutions",
-        "publicEcrTag": "v1.0.3",
+        "publicEcrTag": "v1.0.4",
         "s3LogsArchiveRetentionInDays": 365,
         "s3LogsGlacierRetentionInDays": 2555,
         "sendAnonymizedUsageMetrics": "true",
         "solutionId": "SO0284",
         "solutionName": "innovation-sandbox-on-aws",
-        "version": "v1.0.3",
+        "version": "v1.0.4",
       },
     },
   },
@@ -5094,7 +5209,7 @@ phases:
               ],
             },
             "POWERTOOLS_SERVICE_NAME": "innovation-sandbox",
-            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.3",
+            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.4",
           },
         },
         "FunctionName": {
@@ -6027,7 +6142,7 @@ phases:
                 "sandboxOuId",
               ],
             },
-            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.3",
+            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.4",
           },
         },
         "FunctionName": {
@@ -6732,7 +6847,7 @@ phases:
                 "sandboxOuId",
               ],
             },
-            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.3",
+            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.4",
           },
         },
         "FunctionName": {
@@ -7296,7 +7411,7 @@ phases:
                 },
               ],
             },
-            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.3",
+            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.4",
           },
         },
         "FunctionName": {
@@ -7577,7 +7692,7 @@ phases:
                 },
               ],
             },
-            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.3",
+            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.4",
           },
         },
         "FunctionName": {
@@ -8089,7 +8204,7 @@ phases:
               ],
             },
             "POWERTOOLS_SERVICE_NAME": "innovation-sandbox",
-            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.3",
+            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.4",
           },
         },
         "FunctionName": {
@@ -8473,14 +8588,22 @@ phases:
           "HttpVersion": "http2",
           "IPV6Enabled": true,
           "Logging": {
-            "Bucket": {
-              "Fn::GetAtt": [
-                "CloudFrontUiApiIsbFrontEndAccessLogsBucketB8ACDB31",
-                "RegionalDomainName",
-              ],
-            },
-            "IncludeCookies": true,
-            "Prefix": "isb-fe-logs/",
+            "Fn::If": [
+              "CloudFrontUiApiSupportsCloudFrontLoggingF1020F6E",
+              {
+                "Bucket": {
+                  "Fn::GetAtt": [
+                    "CloudFrontUiApiIsbFrontEndAccessLogsBucketB8ACDB31",
+                    "DomainName",
+                  ],
+                },
+                "IncludeCookies": true,
+                "Prefix": "isb-fe-logs/",
+              },
+              {
+                "Ref": "AWS::NoValue",
+              },
+            ],
           },
           "Origins": [
             {
@@ -8664,6 +8787,7 @@ phases:
       "Type": "AWS::CloudFront::ResponseHeadersPolicy",
     },
     "CloudFrontUiApiIsbFrontEndAccessLogsBucketB8ACDB31": {
+      "Condition": "CloudFrontUiApiSupportsCloudFrontLoggingF1020F6E",
       "DeletionPolicy": "Retain",
       "Metadata": {
         "guard": {
@@ -8754,6 +8878,7 @@ phases:
       "UpdateReplacePolicy": "Retain",
     },
     "CloudFrontUiApiIsbFrontEndAccessLogsBucketPolicyC5EC85B6": {
+      "Condition": "CloudFrontUiApiSupportsCloudFrontLoggingF1020F6E",
       "Properties": {
         "Bucket": {
           "Ref": "CloudFrontUiApiIsbFrontEndAccessLogsBucketB8ACDB31",
@@ -9126,7 +9251,7 @@ phases:
               ],
             },
             "POWERTOOLS_SERVICE_NAME": "innovation-sandbox",
-            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.3",
+            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.4",
           },
         },
         "FunctionName": {
@@ -9403,7 +9528,7 @@ phases:
               ],
             },
             "POWERTOOLS_SERVICE_NAME": "innovation-sandbox",
-            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.3",
+            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.4",
           },
         },
         "FunctionName": {
@@ -10011,7 +10136,7 @@ phases:
               ],
             },
             "POWERTOOLS_SERVICE_NAME": "innovation-sandbox",
-            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.3",
+            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.4",
           },
         },
         "FunctionName": {
@@ -10492,7 +10617,7 @@ phases:
               ],
             },
             "POWERTOOLS_SERVICE_NAME": "innovation-sandbox",
-            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.3",
+            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.4",
           },
         },
         "FunctionName": {
@@ -15239,7 +15364,7 @@ phases:
               ],
             },
             "POWERTOOLS_SERVICE_NAME": "innovation-sandbox",
-            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.3",
+            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.4",
           },
         },
         "FunctionName": {
@@ -15761,7 +15886,7 @@ phases:
               ],
             },
             "POWERTOOLS_SERVICE_NAME": "innovation-sandbox",
-            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.3",
+            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.4",
           },
         },
         "FunctionName": {
@@ -16071,7 +16196,7 @@ phases:
               ],
             },
             "POWERTOOLS_SERVICE_NAME": "innovation-sandbox",
-            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.3",
+            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.4",
           },
         },
         "FunctionName": {
@@ -16460,7 +16585,7 @@ phases:
               ],
             },
             "POWERTOOLS_SERVICE_NAME": "innovation-sandbox",
-            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.3",
+            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.4",
           },
         },
         "FunctionName": {
@@ -16926,7 +17051,7 @@ phases:
                 "sandboxOuId",
               ],
             },
-            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.3",
+            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.4",
           },
         },
         "FunctionName": {
@@ -17465,7 +17590,7 @@ phases:
               ],
             },
             "POWERTOOLS_SERVICE_NAME": "innovation-sandbox",
-            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.3",
+            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.4",
           },
         },
         "FunctionName": {
@@ -18313,7 +18438,7 @@ fields @timestamp, @message
                 "sandboxOuId",
               ],
             },
-            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.3",
+            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.4",
           },
         },
         "FunctionName": {
@@ -19025,7 +19150,7 @@ fields @timestamp, @message
               ],
             },
             "POWERTOOLS_SERVICE_NAME": "SsoHandler",
-            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.3",
+            "USER_AGENT_EXTRA": "AwsSolution/SO0284/v1.0.4",
           },
         },
         "FunctionName": {
@@ -19322,13 +19447,13 @@ exports[`IsbDataStack Snapshot > matches the snapshot 1`] = `
         "deploymentMode": "prod",
         "logLevel": "INFO",
         "publicEcrRegistry": "public.ecr.aws/aws-solutions",
-        "publicEcrTag": "v1.0.3",
+        "publicEcrTag": "v1.0.4",
         "s3LogsArchiveRetentionInDays": 365,
         "s3LogsGlacierRetentionInDays": 2555,
         "sendAnonymizedUsageMetrics": "true",
         "solutionId": "SO0284",
         "solutionName": "innovation-sandbox-on-aws",
-        "version": "v1.0.3",
+        "version": "v1.0.4",
       },
     },
   },

--- a/source/lambdas/account-cleanup/initialize-cleanup/package.json
+++ b/source/lambdas/account-cleanup/initialize-cleanup/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amzn/innovation-sandbox-initialize-cleanup",
   "description": "Initialize Cleanup - Lambda - Innovation Sandbox on AWS (SO0284)",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "build": "tsc",
     "test": "vitest run"

--- a/source/lambdas/account-management/account-drift-monitoring/package.json
+++ b/source/lambdas/account-management/account-drift-monitoring/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amzn/innovation-sandbox-account-drift-monitoring",
   "description": "Account Drift Monitoring - Lambda - Innovation Sandbox on AWS (SO0284)",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "build": "tsc",
     "test": "vitest run"

--- a/source/lambdas/account-management/account-lifecycle-management/package.json
+++ b/source/lambdas/account-management/account-lifecycle-management/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amzn/innovation-sandbox-account-lifecycle-management",
   "description": "Account OU Management - Lambda - Innovation Sandbox on AWS (SO0284)",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "build": "tsc",
     "test": "vitest run"

--- a/source/lambdas/account-management/lease-monitoring/package.json
+++ b/source/lambdas/account-management/lease-monitoring/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amzn/innovation-sandbox-lease-monitoring",
   "description": "Lease Monitoring - Lambda - Innovation Sandbox on AWS (SO0284)",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "build": "tsc",
     "test": "vitest run"

--- a/source/lambdas/api/accounts/package.json
+++ b/source/lambdas/api/accounts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amzn/innovation-sandbox-accounts",
   "description": "Accounts - Lambda - Innovation Sandbox on AWS (SO0284)",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "build": "tsc",
     "test": "vitest run"

--- a/source/lambdas/api/authorizer/package.json
+++ b/source/lambdas/api/authorizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amzn/innovation-sandbox-authorizer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "API Authorizer - Lambda - Innovation Sandbox on AWS (SO0284)",
   "main": "index.js",
   "scripts": {

--- a/source/lambdas/api/configurations/package.json
+++ b/source/lambdas/api/configurations/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amzn/innovation-sandbox-configurations",
   "description": "Configurations - Lambda - Innovation Sandbox on AWS (SO0284)",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "build": "tsc",
     "test": "vitest run"

--- a/source/lambdas/api/lease-templates/package.json
+++ b/source/lambdas/api/lease-templates/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amzn/innovation-sandbox-lease-templates",
   "description": "Lease Templates - Lambda - Innovation Sandbox on AWS (SO0284)",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "build": "tsc",
     "test": "vitest run"

--- a/source/lambdas/api/leases/package.json
+++ b/source/lambdas/api/leases/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amzn/innovation-sandbox-leases",
   "description": "Leases - Lambda - Innovation Sandbox on AWS (SO0284)",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "build": "tsc",
     "test": "vitest run"

--- a/source/lambdas/api/sso-handler/package.json
+++ b/source/lambdas/api/sso-handler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amzn/innovation-sandbox-sso-handler",
   "description": "SSO Handler - Lambda - Innovation Sandbox on AWS (SO0284)",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "type": "module",
   "scripts": {
     "build": "tsc",

--- a/source/lambdas/custom-resources/cost-allocation-tag-activator/package.json
+++ b/source/lambdas/custom-resources/cost-allocation-tag-activator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amzn/innovation-sandbox-cost-allocation-tag-activator",
   "description": "Activates the Innovation Sandbox Cost Allocation Tag - Lambda - Innovation Sandbox on AWS (SO0284)",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "build": "tsc",
     "test": "vitest run"

--- a/source/lambdas/custom-resources/deployment-uuid/package.json
+++ b/source/lambdas/custom-resources/deployment-uuid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amzn/innovation-sandbox-deployment-uuid",
   "description": "Deployment UUID - Lambda - Innovation Sandbox on AWS (SO0284)",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "build": "tsc",
     "test": "vitest run"

--- a/source/lambdas/custom-resources/idc-configurer/package.json
+++ b/source/lambdas/custom-resources/idc-configurer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amzn/innovation-sandbox-idc-configurer",
   "description": "IDC Configurer - Lambda - Innovation Sandbox on AWS (SO0284)",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "build": "tsc",
     "test": "vitest run"

--- a/source/lambdas/custom-resources/shared-json-param-parser/package.json
+++ b/source/lambdas/custom-resources/shared-json-param-parser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amzn/innovation-sandbox-shared-json-param-parser",
   "description": "Parsed shared SSM configuration parameters from spoke stacks - Lambda - Innovation Sandbox on AWS (SO0284)",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "build": "tsc",
     "test": "vitest run"

--- a/source/lambdas/helpers/secret-rotator/package.json
+++ b/source/lambdas/helpers/secret-rotator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amzn/innovation-sandbox-secret-rotator",
   "description": "Rotates the JWT secret - Lambda - Innovation Sandbox on AWS (SO0284)",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "build": "tsc",
     "test": "vitest run"

--- a/source/lambdas/metrics/cost-reporting/package.json
+++ b/source/lambdas/metrics/cost-reporting/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amzn/innovation-sandbox-cost-reporting",
   "description": "Cost Reporting - Lambda - Innovation Sandbox on AWS (SO0284)",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "build": "tsc",
     "test": "vitest run"

--- a/source/lambdas/metrics/deployment-summary-heartbeat/package.json
+++ b/source/lambdas/metrics/deployment-summary-heartbeat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amzn/innovation-sandbox-metrics-heartbeat",
   "description": "Heartbeat - Lambda - Innovation Sandbox on AWS (SO0284)",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "build": "tsc",
     "test": "vitest run"

--- a/source/lambdas/metrics/log-archiving/package.json
+++ b/source/lambdas/metrics/log-archiving/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amzn/innovation-sandbox-log-archiving",
   "description": "Log archiving - Lambda - Innovation Sandbox on AWS (SO0284)",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "build": "tsc",
     "test": "vitest run"

--- a/source/lambdas/metrics/log-subscriber/package.json
+++ b/source/lambdas/metrics/log-subscriber/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amzn/innovation-sandbox-metrics-log-subscriber",
   "description": "Log Subscriber - Lambda - Innovation Sandbox on AWS (SO0284)",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "build": "tsc",
     "test": "vitest run"

--- a/source/lambdas/notification/email-notification/package.json
+++ b/source/lambdas/notification/email-notification/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@amzn/innovation-sandbox-email-notification",
   "description": "Email notification - Lambda - Innovation Sandbox on AWS (SO0284)",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "build": "tsc",
     "test": "vitest run"

--- a/source/layers/common/package-lock.json
+++ b/source/layers/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amzn/innovation-sandbox-layer-commons",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amzn/innovation-sandbox-layer-commons",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@amzn/innovation-sandbox-commons": "file:../../common"

--- a/source/layers/common/package.json
+++ b/source/layers/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amzn/innovation-sandbox-layer-commons",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Common Libs - Lambda Layer - Innovation Sandbox on AWS (SO0284)",
   "dependencies": {
     "@amzn/innovation-sandbox-commons": "file:../../common"

--- a/source/layers/dependencies/package-lock.json
+++ b/source/layers/dependencies/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@amzn/innovation-sandbox-layer-dependencies",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amzn/innovation-sandbox-layer-dependencies",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-lambda-powertools/logger": "^2.2.0",
@@ -2970,9 +2970,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
-      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
+      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/source/layers/dependencies/package.json
+++ b/source/layers/dependencies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amzn/innovation-sandbox-layer-dependencies",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Dependencies - Lambda Layer - Innovation Sandbox on AWS (SO0284)",
   "dependencies": {
     "@aws-lambda-powertools/logger": "^2.2.0",


### PR DESCRIPTION
## [1.0.4] - 2025-09-02

### Added

- Conditional deployment of CloudFront access logs to support regions that don't support standard logging (legacy)
- Missing AppConfig Lambda layer extension ARN for eu-central-2 region

### Fixed

- Deployment failures in regions that don't support CloudFront standard access logging (legacy)
