### PR TITLE
Add ECS Service Linked Role to sandbox accounts

### DIFF
--- a/source/infrastructure/lib/components/config/nuke-config.yaml
+++ b/source/infrastructure/lib/components/config/nuke-config.yaml
@@ -69,8 +69,6 @@ accounts:
           value: "%CLEANUP_ROLE_NAME%" # placeholder CLEANUP_ROLE_NAME will be dynamically replaced during CodeBuild executio
         - type: exact
           value: OrganizationAccountAccessRole
-        - type: exact
-          value: AWSServiceRoleForECS # ECS Service Linked Role
         - type: glob
           value: stacksets-exec-*
         - type: glob
@@ -86,9 +84,6 @@ accounts:
         - property: "role:RoleName"
           type: exact
           value: OrganizationAccountAccessRole
-        - property: "role:RoleName"
-          type: exact
-          value: AWSServiceRoleForECS # ECS Service Linked Role
         - property: "role:RoleName"
           type: glob
           value: stacksets-exec-*
@@ -108,9 +103,6 @@ accounts:
           type: exact
           value: OrganizationAccountAccessRole
         - property: RoleName
-          type: exact
-          value: AWSServiceRoleForECS # ECS Service Linked Role
-        - property: RoleName
           type: glob
           value: stacksets-exec-*
         - type: glob
@@ -121,6 +113,9 @@ accounts:
         - property: RoleName
           type: glob
           value: aws-controltower-*
+      IAMServiceLinkedRole:
+        - type: exact
+          value: AWSServiceRoleForECS # ECS Service Linked Role
       IAMSAMLProvider:
         - type: contains
           value: AWSSSO

--- a/source/infrastructure/lib/components/config/nuke-config.yaml
+++ b/source/infrastructure/lib/components/config/nuke-config.yaml
@@ -69,6 +69,8 @@ accounts:
           value: "%CLEANUP_ROLE_NAME%" # placeholder CLEANUP_ROLE_NAME will be dynamically replaced during CodeBuild executio
         - type: exact
           value: OrganizationAccountAccessRole
+        - type: exact
+          value: AWSServiceRoleForECS # ECS Service Linked Role
         - type: glob
           value: stacksets-exec-*
         - type: glob
@@ -84,6 +86,9 @@ accounts:
         - property: "role:RoleName"
           type: exact
           value: OrganizationAccountAccessRole
+        - property: "role:RoleName"
+          type: exact
+          value: AWSServiceRoleForECS # ECS Service Linked Role
         - property: "role:RoleName"
           type: glob
           value: stacksets-exec-*
@@ -102,6 +107,9 @@ accounts:
         - property: RoleName
           type: exact
           value: OrganizationAccountAccessRole
+        - property: RoleName
+          type: exact
+          value: AWSServiceRoleForECS # ECS Service Linked Role
         - property: RoleName
           type: glob
           value: stacksets-exec-*

--- a/source/infrastructure/lib/isb-sandbox-account-resources.ts
+++ b/source/infrastructure/lib/isb-sandbox-account-resources.ts
@@ -8,6 +8,7 @@ import {
   PolicyStatement,
   PrincipalWithConditions,
   Role,
+  ServicePrincipal,
 } from "aws-cdk-lib/aws-iam";
 import { Construct } from "constructs";
 
@@ -58,6 +59,25 @@ export class IsbSandboxAccountResources {
       "CFN_NO_EXPLICIT_RESOURCE_NAMES",
       "IAM_NO_INLINE_POLICY_CHECK",
       "IAM_POLICYDOCUMENT_NO_WILDCARD_RESOURCE",
+    ]);
+
+    // ECS Service Linked Role
+    // This ensures ECS clusters can be created without permission issues
+    const ecsServiceLinkedRole = new Role(scope, "ECSServiceLinkedRole", {
+      roleName: "AWSServiceRoleForECS",
+      description: "Service-linked role for Amazon ECS",
+      assumedBy: new ServicePrincipal("ecs.amazonaws.com"),
+      managedPolicies: [
+        {
+          managedPolicyArn: "arn:aws:iam::aws:policy/aws-service-role/ECSServiceRolePolicy",
+        },
+      ],
+      path: "/aws-service-role/ecs.amazonaws.com/",
+    });
+
+    addCfnGuardSuppression(ecsServiceLinkedRole, [
+      "CFN_NO_EXPLICIT_RESOURCE_NAMES",
+      "IAM_NO_INLINE_POLICY_CHECK",
     ]);
   }
 }

--- a/source/infrastructure/test/__snapshots__/snapshots.test.ts.snap
+++ b/source/infrastructure/test/__snapshots__/snapshots.test.ts.snap
@@ -19912,8 +19912,6 @@ accounts:
           value: "%CLEANUP_ROLE_NAME%" # placeholder CLEANUP_ROLE_NAME will be dynamically replaced during CodeBuild executio
         - type: exact
           value: OrganizationAccountAccessRole
-        - type: exact
-          value: AWSServiceRoleForECS # ECS Service Linked Role
         - type: glob
           value: stacksets-exec-*
         - type: glob
@@ -19929,9 +19927,6 @@ accounts:
         - property: "role:RoleName"
           type: exact
           value: OrganizationAccountAccessRole
-        - property: "role:RoleName"
-          type: exact
-          value: AWSServiceRoleForECS # ECS Service Linked Role
         - property: "role:RoleName"
           type: glob
           value: stacksets-exec-*
@@ -19951,9 +19946,6 @@ accounts:
           type: exact
           value: OrganizationAccountAccessRole
         - property: RoleName
-          type: exact
-          value: AWSServiceRoleForECS # ECS Service Linked Role
-        - property: RoleName
           type: glob
           value: stacksets-exec-*
         - type: glob
@@ -19964,6 +19956,9 @@ accounts:
         - property: RoleName
           type: glob
           value: aws-controltower-*
+      IAMServiceLinkedRole:
+        - type: exact
+          value: AWSServiceRoleForECS # ECS Service Linked Role
       IAMSAMLProvider:
         - type: contains
           value: AWSSSO
@@ -20502,36 +20497,12 @@ exports[`SandboxAccountStack Snapshot > matches the snapshot 1`] = `
     },
   },
   "Resources": {
-    "ECSServiceLinkedRole67CE650F": {
-      "Metadata": {
-        "guard": {
-          "SuppressedRules": [
-            "CFN_NO_EXPLICIT_RESOURCE_NAMES",
-            "IAM_NO_INLINE_POLICY_CHECK",
-          ],
-        },
-      },
+    "ECSServiceLinkedRole": {
       "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "ecs.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "Description": "Service-linked role for Amazon ECS",
-        "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/aws-service-role/ECSServiceRolePolicy",
-        ],
-        "Path": "/aws-service-role/ecs.amazonaws.com/",
-        "RoleName": "AWSServiceRoleForECS",
+        "AWSServiceName": "ecs.amazonaws.com",
+        "Description": "Role to enable Amazon ECS to manage your cluster.",
       },
-      "Type": "AWS::IAM::Role",
+      "Type": "AWS::IAM::ServiceLinkedRole",
     },
     "SandboxAccountRole39551795": {
       "Metadata": {

--- a/source/infrastructure/test/__snapshots__/snapshots.test.ts.snap
+++ b/source/infrastructure/test/__snapshots__/snapshots.test.ts.snap
@@ -19912,6 +19912,8 @@ accounts:
           value: "%CLEANUP_ROLE_NAME%" # placeholder CLEANUP_ROLE_NAME will be dynamically replaced during CodeBuild executio
         - type: exact
           value: OrganizationAccountAccessRole
+        - type: exact
+          value: AWSServiceRoleForECS # ECS Service Linked Role
         - type: glob
           value: stacksets-exec-*
         - type: glob
@@ -19927,6 +19929,9 @@ accounts:
         - property: "role:RoleName"
           type: exact
           value: OrganizationAccountAccessRole
+        - property: "role:RoleName"
+          type: exact
+          value: AWSServiceRoleForECS # ECS Service Linked Role
         - property: "role:RoleName"
           type: glob
           value: stacksets-exec-*
@@ -19945,6 +19950,9 @@ accounts:
         - property: RoleName
           type: exact
           value: OrganizationAccountAccessRole
+        - property: RoleName
+          type: exact
+          value: AWSServiceRoleForECS # ECS Service Linked Role
         - property: RoleName
           type: glob
           value: stacksets-exec-*
@@ -20494,6 +20502,37 @@ exports[`SandboxAccountStack Snapshot > matches the snapshot 1`] = `
     },
   },
   "Resources": {
+    "ECSServiceLinkedRole67CE650F": {
+      "Metadata": {
+        "guard": {
+          "SuppressedRules": [
+            "CFN_NO_EXPLICIT_RESOURCE_NAMES",
+            "IAM_NO_INLINE_POLICY_CHECK",
+          ],
+        },
+      },
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Description": "Service-linked role for Amazon ECS",
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/aws-service-role/ECSServiceRolePolicy",
+        ],
+        "Path": "/aws-service-role/ecs.amazonaws.com/",
+        "RoleName": "AWSServiceRoleForECS",
+      },
+      "Type": "AWS::IAM::Role",
+    },
     "SandboxAccountRole39551795": {
       "Metadata": {
         "guard": {


### PR DESCRIPTION
### Summary
Adds ECS Service Linked Role (`AWSServiceRoleForECS`) to sandbox account resources to resolve ECS cluster creation failures


<img width="1904" height="1534" alt="Screenshot from 2025-09-27 10-08-57" src="https://github.com/user-attachments/assets/89d015a5-29c1-41cc-a7ac-98f87d96517c" />


### Changes
- Add `CfnServiceLinkedRole` for ECS service in `IsbSandboxAccountResources`
- Configure proper cleanup exclusion for `IAMServiceLinkedRole` in nuke-config.yaml
- Add cfn-guard suppression using direct metadata approach

### Problem Solved
Fixes "Unable to assume the service linked role" error when creating ECS clusters in sandbox accounts.

### Testing
- ✅ Build successful
- ✅ Infrastructure tests pass
- ✅ Snapshots updated