### PR TITLE
Add execute-api to SCP Not-Deny Action for WebSocket API

### DIFF
--- a/source/infrastructure/lib/components/service-control-policies/isb-aws-nuke-supported-services-scp.json
+++ b/source/infrastructure/lib/components/service-control-policies/isb-aws-nuke-supported-services-scp.json
@@ -11,6 +11,7 @@
         "amplify:*",
         "aoss:*",
         "apigateway:*",
+        "execute-api:*",
         "appconfig:*",
         "application-autoscaling:*",
         "applicationinsights:*",

--- a/source/infrastructure/test/__snapshots__/snapshots.test.ts.snap
+++ b/source/infrastructure/test/__snapshots__/snapshots.test.ts.snap
@@ -2333,6 +2333,7 @@ exports[`IsbAccountPoolStack Snapshot > matches the snapshot 1`] = `
                 "amplify:*",
                 "aoss:*",
                 "apigateway:*",
+                "execute-api:*",
                 "appconfig:*",
                 "application-autoscaling:*",
                 "applicationinsights:*",


### PR DESCRIPTION
## PR Summary

I encountered an error when attempting to connect a WebSocket using a Sandbox account.
This was because the execute-api:ManageConnections command was being denied via SCP.

```
An error occurred (AccessDeniedException) when calling the PostToConnection operation: 
User: arn:aws:sts::123412341234:assumed-role/websocket-handler-role-enk7x5b2/websocket-handler
is not authorized to perform: execute-api:ManageConnections on resource: 
arn:aws:execute-api:us-east-1:********8190:zgeh0r2vv1/prod/POST/@connections/{connectionId} 
with an explicit deny in a service control policy
```

This PR adds execute-api to the AWS Nuke supported services list, enabling proper cleanup of WebSocket API resources.

## Changes

Added execute-api:* to isb-aws-nuke-supported-services-scp.json

## Updated corresponding test snapshots

### Technical Background (from AWS official documentation)

1. Automatic Disconnection of WebSocket Connections
WebSocket connections are automatically disconnected after a 10-minute idle timeout:
> API Gateway returns this status code when the client is idle for 10 minutes or reaches the maximum 2-hour connection lifetime.
Reference URL: https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-overview.html

2. Regarding the Definition of execute-api:ManageConnections
execute-api:ManageConnections is defined as an action, not a resource:
> The execute-api action supports ManageConnections in addition to existing actions (Invoke, InvalidateCache). ManageConnections controls access to the @connections API.
Reference URL: https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-control-access-iam.html

3. AWS Nuke Behavior
AWS Nuke does not target actions for deletion, so the execute-api:ManageConnections action itself will not be deleted. However, deleting the WebSocket API resource prevents new connections and existing connections will automatically time out and disconnect.

## Expected Effects

- Proper cleanup of the WebSocket API resource
- Automatic disconnection of existing connections via a 10-minute timeout
- This error will be resolved.

```
An error occurred (AccessDeniedException) when calling the PostToConnection operation: 
User: arn:aws:sts::123412341234:assumed-role/websocket-handler-role-enk7x5b2/websocket-handler
is not authorized to perform: execute-api:ManageConnections on resource: 
arn:aws:execute-api:us-east-1:********8190:zgeh0r2vv1/prod/POST/@connections/{connectionId} 
with an explicit deny in a service control policy
```