### PR TITLE
feat: add manual quarantine option for sandbox accounts

### DIFF
--- a/source/frontend/src/domains/accounts/hooks.ts
+++ b/source/frontend/src/domains/accounts/hooks.ts
@@ -55,3 +55,15 @@ export const useCleanupAccount = () => {
       client.invalidateQueries({ queryKey: ["accounts"], refetchType: "all" }),
   });
 };
+
+export const useQuarantineAccount = () => {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: async (awsAccountId: string) =>
+      await new AccountService().quarantineAccount(awsAccountId),
+    onSuccess: () => {
+      client.invalidateQueries({ queryKey: ["accounts"], refetchType: "all" });
+      client.invalidateQueries({ queryKey: ["leases"], refetchType: "all" });
+    },
+  });
+};

--- a/source/frontend/src/domains/accounts/service.ts
+++ b/source/frontend/src/domains/accounts/service.ts
@@ -72,4 +72,8 @@ export class AccountService {
   async cleanupAccount(awsAccountId: string): Promise<void> {
     await this.api.post(`/accounts/${awsAccountId}/retryCleanup`);
   }
+
+  async quarantineAccount(awsAccountId: string): Promise<void> {
+    await this.api.post(`/accounts/${awsAccountId}/quarantine`);
+  }
 }

--- a/source/infrastructure/lib/components/api/accounts-api.ts
+++ b/source/infrastructure/lib/components/api/accounts-api.ts
@@ -130,6 +130,10 @@ export class AccountsApi {
     const accountEjectResource = accountIdResource.addResource("eject");
     accountEjectResource.addMethod("POST");
 
+    const accountQuarantineResource =
+      accountIdResource.addResource("quarantine");
+    accountQuarantineResource.addMethod("POST");
+
     const accountsUnregisteredResource =
       accountsResource.addResource("unregistered");
     accountsUnregisteredResource.addMethod("GET");


### PR DESCRIPTION
This PR provides an example implementation for issue #85.

## Summary

Adds a "Quarantine" option to the account Actions dropdown, allowing administrators to manually quarantine accounts when issues are detected (e.g., exhausted quotas, suspected compromise, incomplete cleanup).

## Changes

- **Backend API**: Added `POST /accounts/{awsAccountId}/quarantine` endpoint with validation (blocks if already `Quarantine` or `CleanUp`)
- **API Gateway**: Registered quarantine resource under account ID path
- **Frontend Service**: Added `quarantineAccount()` method
- **Frontend Hook**: Added `useQuarantineAccount()` with cache invalidation for accounts and leases
- **UI**: Added "Quarantine" item to Actions dropdown with appropriate disabled states

## Implementation Notes

This leverages the existing `InnovationSandbox.quarantineAccount()` business logic, which handles lease termination and OU moves. No changes to core quarantine behaviour were required.

## Note to Maintainers

We understand that AWS Solutions' contribution policy means external code isn't merged directly. This PR is offered as a reference implementation to illustrate one possible approach, in case it's helpful as you consider the feature request. 

Thank you for your consideration, and for maintaining this project.

Closes #85