### PR TITLE
feat: include AWS credits in cost accounting

### DIFF
--- a/source/common/isb-services/cost-explorer-service.ts
+++ b/source/common/isb-services/cost-explorer-service.ts
@@ -108,15 +108,6 @@ export class CostExplorerService {
               },
             },
             {
-              Not: {
-                Dimensions: {
-                  Key: "RECORD_TYPE",
-                  Values: ["Credit", "Refund"],
-                  MatchOptions: ["EQUALS"],
-                },
-              },
-            },
-            {
               Tags: {
                 Key: tag.tagName,
                 MatchOptions: ["EQUALS"],
@@ -141,23 +132,10 @@ export class CostExplorerService {
         Granularity: granularity,
         Metrics: ["UnblendedCost"],
         Filter: {
-          And: [
-            {
-              Dimensions: {
-                Key: "LINKED_ACCOUNT",
-                Values: accounts,
-              },
-            },
-            {
-              Not: {
-                Dimensions: {
-                  Key: "RECORD_TYPE",
-                  Values: ["Credit", "Refund"],
-                  MatchOptions: ["EQUALS"],
-                },
-              },
-            },
-          ],
+          Dimensions: {
+            Key: "LINKED_ACCOUNT",
+            Values: accounts,
+          },
         },
         GroupBy: [
           {

--- a/source/common/test/isb-services/cost-explorer-service.test.ts
+++ b/source/common/test/isb-services/cost-explorer-service.test.ts
@@ -122,23 +122,10 @@ describe("CostExplorerService", () => {
         Granularity: Granularity.DAILY,
         Metrics: ["UnblendedCost"],
         Filter: {
-          And: [
-            {
-              Dimensions: {
-                Key: "LINKED_ACCOUNT",
-                Values: accounts,
-              },
-            },
-            {
-              Not: {
-                Dimensions: {
-                  Key: "RECORD_TYPE",
-                  Values: ["Credit", "Refund"],
-                  MatchOptions: ["EQUALS"],
-                },
-              },
-            },
-          ],
+          Dimensions: {
+            Key: "LINKED_ACCOUNT",
+            Values: accounts,
+          },
         },
         GroupBy: [
           {


### PR DESCRIPTION
This PR provides an implementation for issue #97.

  ## Summary
  Removes the RECORD_TYPE filter that excludes Credit/Refund records from Cost Explorer queries, allowing organizations using AWS Credits to see actual resource consumption in cost reports.

  ## Changes
  - **cost-explorer-service.ts**: Removed Credit/Refund exclusion filter from `getGetCostAndUsageCommandInput()` method
  - **cost-explorer-service.test.ts**: Updated test expectations to reflect new filter structure

  ## Problem
  Organizations that primarily use AWS Credits (educational institutions, startups with AWS Activate, etc.) see $0 in cost reports because Credit/Refund records are filtered out. This makes it difficult to track resource consumption, enforce budget thresholds, and report on credit utilization.

  ## Testing
  - All 716 existing tests pass

  ## Note to Maintainers
  We understand that this change affects all deployments. If a configuration toggle is preferred (to let admins choose whether to include credits), we're happy to implement that instead. This PR is offered as a starting point for discussion.

  Thank you for maintaining this project.

  Closes #97

  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms
of your choice.