### PR TITLE
feat(account-pool): support custom OU name

### DIFF
--- a/source/infrastructure/lib/isb-account-pool-resources.ts
+++ b/source/infrastructure/lib/isb-account-pool-resources.ts
@@ -59,6 +59,7 @@ const supportedSchemas = ["1"];
 
 export interface IsbAccountPoolResourcesProps {
   readonly namespace: string;
+  readonly accountPoolOuName: string;
   readonly parentOuId: string;
   readonly hubAccountId: string;
   readonly isbManagedRegions: string[];
@@ -72,7 +73,7 @@ export class IsbAccountPoolResources {
       scope,
       "InnovationSandboxAccountPoolOu",
       {
-        name: `${props.namespace}_InnovationSandboxAccountPool`,
+        name: props.accountPoolOuName,
         parentId: props.parentOuId,
       },
     );

--- a/source/infrastructure/lib/isb-account-pool-stack.ts
+++ b/source/infrastructure/lib/isb-account-pool-stack.ts
@@ -5,6 +5,7 @@ import { Construct } from "constructs";
 
 import {
   addParameterGroup,
+  OptionalParameter,
   ParameterWithLabel,
 } from "@amzn/innovation-sandbox-infrastructure/helpers/cfn-utils";
 import {
@@ -23,6 +24,14 @@ export class IsbAccountPoolStack extends Stack {
     const namespaceParam = new NamespaceParam(this);
 
     const hubAccountIdParam = new HubAccountIdParam(this);
+
+    const accountPoolOuName = new OptionalParameter(this, "AccountPoolOuName", {
+      label: "Account Pool OU Name (Optional)",
+      description:
+        "A custom name to provide for the top-level account pool OU (value if left empty: <namespace>_InnovationSandboxAccountPool).",
+      maxLength: 128,
+      valueIfEmpty: `${namespaceParam.valueAsString}_InnovationSandboxAccountPool`,
+    });
 
     const parentOuId = new ParameterWithLabel(this, "ParentOuId", {
       label: "Parent OU Id",
@@ -51,6 +60,7 @@ export class IsbAccountPoolStack extends Stack {
       parameters: [
         namespaceParam,
         hubAccountIdParam,
+        accountPoolOuName,
         parentOuId,
         isbManagedRegions,
       ],
@@ -58,6 +68,7 @@ export class IsbAccountPoolStack extends Stack {
 
     new IsbAccountPoolResources(this, {
       namespace: namespaceParam.valueAsString,
+      accountPoolOuName: accountPoolOuName.resolve(),
       parentOuId: parentOuId.valueAsString,
       hubAccountId: hubAccountIdParam.valueAsString,
       isbManagedRegions: isbManagedRegions.valueAsList,

--- a/source/infrastructure/test/__snapshots__/snapshots.test.ts.snap
+++ b/source/infrastructure/test/__snapshots__/snapshots.test.ts.snap
@@ -1398,6 +1398,9 @@ exports[`IsbAccountPoolStack Snapshot > matches the snapshot 1`] = `
         "HubAccountId": {
           "default": "Hub Account Id"
         },
+        "AccountPoolOuName": {
+          "default": "Account Pool OU Name (Optional)"
+        },
         "ParentOuId": {
           "default": "Parent OU Id"
         },
@@ -1413,6 +1416,7 @@ exports[`IsbAccountPoolStack Snapshot > matches the snapshot 1`] = `
           "Parameters": [
             "Namespace",
             "HubAccountId",
+            "AccountPoolOuName",
             "ParentOuId",
             "IsbManagedRegions"
           ]
@@ -1432,6 +1436,12 @@ exports[`IsbAccountPoolStack Snapshot > matches the snapshot 1`] = `
       "AllowedPattern": "^[0-9]{12}$",
       "Description": "The AWS Account Id where the Innovation Sandbox hub application is (to be) deployed"
     },
+    "AccountPoolOuName": {
+      "Type": "String",
+      "Default": "",
+      "MaxLength": 128,
+      "Description": "A custom name to provide for the top-level account pool OU (value if left empty: <namespace>_InnovationSandboxAccountPool)."
+    },
     "ParentOuId": {
       "Type": "String",
       "AllowedPattern": "^(r-[0-9a-z]{4,32})|(ou-[0-9a-z]{4,32}-[a-z0-9]{8,32})$",
@@ -1449,19 +1459,37 @@ exports[`IsbAccountPoolStack Snapshot > matches the snapshot 1`] = `
       "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]"
     }
   },
+  "Conditions": {
+    "AccountPoolOuNameEmptyCondition": {
+      "Fn::Equals": [
+        {
+          "Ref": "AccountPoolOuName"
+        },
+        ""
+      ]
+    }
+  },
   "Resources": {
     "InnovationSandboxAccountPoolOu": {
       "Type": "AWS::Organizations::OrganizationalUnit",
       "Properties": {
         "Name": {
-          "Fn::Join": [
-            "",
-            [
-              {
-                "Ref": "Namespace"
-              },
-              "_InnovationSandboxAccountPool"
-            ]
+          "Fn::If": [
+            "AccountPoolOuNameEmptyCondition",
+            {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "Namespace"
+                  },
+                  "_InnovationSandboxAccountPool"
+                ]
+              ]
+            },
+            {
+              "Ref": "AccountPoolOuName"
+            }
           ]
         },
         "ParentId": {


### PR DESCRIPTION
_Issue_ 

- Closes #145 

_Description of changes:_

- Add an optional CloudFormation parameter `AccountPoolOuName` to allow specifying a custom name for the top-level Innovation Sandbox account pool OU. When left empty the stack falls back to `<namespace>_InnovationSandboxAccountPool`. Expose the parameter as an OptionalParameter on the stack and pass it into the `IsbAccountPoolResources` construct. The generated template uses Fn::If to choose between the provided name and the default. Update unit test snapshot.

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
