### PR TITLE
fix(scp): allow eks-auth:* so EKS Pod Identity works in sandbox accounts

### DIFF
--- a/source/infrastructure/lib/components/service-control-policies/isb-aws-nuke-supported-services-scp.json
+++ b/source/infrastructure/lib/components/service-control-policies/isb-aws-nuke-supported-services-scp.json
@@ -56,6 +56,7 @@
         "ecs:*",
         "elasticfilesystem:*",
         "eks:*",
+        "eks-auth:*",
         "elasticache:*",
         "elasticbeanstalk:*",
         "es:*",

--- a/source/infrastructure/test/__snapshots__/snapshots.test.ts.snap
+++ b/source/infrastructure/test/__snapshots__/snapshots.test.ts.snap
@@ -1739,6 +1739,7 @@ exports[`IsbAccountPoolStack Snapshot > matches the snapshot 1`] = `
                 "ecs:*",
                 "elasticfilesystem:*",
                 "eks:*",
+                "eks-auth:*",
                 "elasticache:*",
                 "elasticbeanstalk:*",
                 "es:*",


### PR DESCRIPTION
_Issue #, if available:_ N/A

_Description of changes:_
The `DenyAllExceptAwsNukeSupportedServices` SCP (`isb-aws-nuke-supported-services-scp.json`) allowlists `eks:*` but not `eks-auth:*`. EKS Pod Identity's credential handshake, `eks-auth:AssumeRoleForPodIdentity`, lives in the separate `eks-auth` IAM namespace, so it is denied by omission on every sandbox account. This breaks the VPC CNI (aws-node), EBS CSI driver, AWS Load Balancer Controller, Karpenter, and any workload that uses Pod Identity - nodes come up `NotReady` because ipamd cannot obtain credentials.

This adds `"eks-auth:*"` to the allowlist. `eks-auth` has no nuke-able resources (the cluster itself is `eks:*`, already allowed and cleaned by aws-nuke), so allowing it does not weaken account cleanup on ejection.

The infrastructure snapshot test was regenerated (`vitest run -u`); all tests pass.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
